### PR TITLE
Fix last slide sticking

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,8 @@ class RCarousel extends Component {
     loop && onInit && onInit();
   }
 
+  isSliderWidthExceedScreen = true
+
   handleViewportResize() {
     this.calcCheckpoints();
     this.goToSlide(this.state.currentIndex, true);
@@ -105,6 +107,7 @@ class RCarousel extends Component {
         );
       }
     );
+    this.isSliderWidthExceedScreen = this.widthTotal > screen.width;
   }
 
   currentDelta = 0;
@@ -151,7 +154,7 @@ class RCarousel extends Component {
       RCarousel.setStylesWithPrefixes(this.innerNode, 0);
     } else
     // Фикс на последний слайд
-    if (nextDelta < maxShift) {
+    if (nextDelta < maxShift && this.isSliderWidthExceedScreen) {
       this.currentIndex = this.state.itemsCount - 1;
       this.currentDelta = maxShift;
       RCarousel.setStylesWithPrefixes(this.innerNode, maxShift);


### PR DESCRIPTION
In wide screens we have such situation: if screen width is greater than slides width then slider moves to the right and we have empty space on the left. So we need to disable sticking to the last slide for such cases.