### PR TITLE
Fix for IE animation

### DIFF
--- a/src/RCarousel.scss
+++ b/src/RCarousel.scss
@@ -14,6 +14,7 @@
   z-index: 1;
   transform: translate3d(0, 0, 0);
   backface-visibility: hidden;
+  -ms-backface-visibility: visible;
   perspective: 1000;
 }
 


### PR DESCRIPTION
If backface is hidden in IE slider shows only first and last frame of the animation. So we need to add `-ms-backface-visibility: visible` to fix this